### PR TITLE
Remove unnecessary case from ConfigParseError

### DIFF
--- a/src/Cfg.hs
+++ b/src/Cfg.hs
@@ -395,7 +395,6 @@ module Cfg (
 --
 -- |
 --
-
   getConfigRaw,
   getConfig,
 ) where

--- a/src/Cfg/Parser.hs
+++ b/src/Cfg/Parser.hs
@@ -23,8 +23,7 @@ import Text.Megaparsec.Char.Lexer qualified as L
 type Parser = Parsec Void Text
 
 data ConfigParseError
-  = UnmatchedFields [Tree Text]
-  | MismatchedRootKey Text Text
+  = MismatchedRootKey Text Text
   | MismatchedKeyAndField Text (Text, Text)
   | MissingKeys [Text]
   | MissingValue Text


### PR DESCRIPTION
Closes #2 